### PR TITLE
Fixed poster display issue from latest merge.

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,10 @@
                     <div class="col-12 col-md-6 text-center">
                         <div class="card mx-auto card-with-gold-border" style="max-width: 22rem;">
                             <!--GIPHY will go here-->
-                            <img id="giphyImg" src=".//assets/images/happyGif.jpg" class="card-img-top img-fluid"
+                            <img id="giphyImg" src="" class="card-img-top img-fluid"
                                 alt="Giphy Img from API">
+                            <img id="posterImg" src="" class="card-img-top img-fluid"
+                                alt="Poster Img from API">
                             <div class="card-body customCardBody">
                                 <!-- Heading indicating whether the player performed well or not -->
                                 <h5 id="happyFeedback" class="card-title">🎉 Well Done !!! 🎉</h5>


### PR DESCRIPTION
In latest merge, the poster img element in the index file was removed, and the src on the giphyImg was added back in.

This should be kept blank and the posterImg **should remain always** as application will not display the poster if this is removed.