### PR TITLE
Implemented live score count and fixed movie name in array.

### DIFF
--- a/assets/js/questionapi.js
+++ b/assets/js/questionapi.js
@@ -1,5 +1,5 @@
 // Array of movies for the quiz.
-var movieArray = ["Poor Things", "Saltburn", "The Lord of the Rings: The Fellowship of the Ring", "Django Unchained", "Finding Nemo", "The Beach", "Shutter Island", "Titanic", "Home Alone", "Superbad", "Shrek", "Pinapple Express", "Legally Blonde", "Lara Croft: Tomb Raider", "Good Will Hunting", "Up", "Bee Movie", "Interstellar", "Fight Club", "Fear and Loathing in Las Vegas", "Click", "Kill Bill", "Cast Away", "Blow", "American Psycho", "A Nightmare on Elm Street", "Pulp Fiction", "The Terminator", "The Dark Knight Rises", "Saving Private Ryan", "Toy Story", "Zombieland", "The Gentlemen", "The Conjuring", "Black Hawk Down", "Avatar The Way of Water"];
+var movieArray = ["Poor Things", "Saltburn", "The Lord of the Rings: The Fellowship of the Ring", "Django Unchained", "Finding Nemo", "The Beach", "Shutter Island", "Titanic", "Home Alone", "Superbad", "Shrek", "Pineapple Express", "Legally Blonde", "Lara Croft: Tomb Raider", "Good Will Hunting", "Up", "Bee Movie", "Interstellar", "Fight Club", "Fear and Loathing in Las Vegas", "Click", "Kill Bill", "Cast Away", "Blow", "American Psycho", "A Nightmare on Elm Street", "Pulp Fiction", "The Terminator", "The Dark Knight Rises", "Saving Private Ryan", "Toy Story", "Zombieland", "The Gentlemen", "The Conjuring", "Black Hawk Down", "Avatar The Way of Water"];
 
 var giphyApiKey = "nZcsHdIXJYfHdyt5y85wKNj1pmrGVGBh";                                                                                                           // Giphy API Key.
 
@@ -106,8 +106,4 @@ function giphyFetch(movie, key) {                                               
         $("#giphyImg").attr("src", `${gifImgURL}`);                                                                                                             // Giving the giphy image tag a src attribute of giphy's gif source url.
     });
 };
-giphyFetch(queryMovie, giphyApiKey);       
-
-// Kick off Logic in this file
-// getQuestion();
-// Calling the giphyFetch function (Passing in queryMovie and giphyApiKey).
+giphyFetch(queryMovie, giphyApiKey);                                                                                                                            // Calling the giphyFetch function (Passing in queryMovie and giphyApiKey). 

--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
     // console.log("In Quiz file --> fetchMovie(): ", movieFetch )
-
+    var score = 30;
     var progressPercentage = 0; // Add this line to declare a global variable for progress
 
     $("#genre").addClass("hide");
@@ -80,7 +80,7 @@ $(document).ready(function () {
         $("#clue1").addClass("hide");
         $("#clue2").removeClass("hide");
         $("#genre").removeClass("hide");
-
+        score = score - 1;
     });
 
     // give me another clue btn
@@ -90,7 +90,7 @@ $(document).ready(function () {
         $("#clue2").addClass("hide");
         $("#plot").removeClass("hide");
         $("#clue3").removeClass("hide");
-
+        score = score - 1;
     });
 
     $("#answerOptions").on("click", function (event) {
@@ -135,6 +135,7 @@ $(document).ready(function () {
         $("#feedback").removeClass("hide");
         $("#sadFeedback").removeClass("hide");
         $("#posterImg").addClass("hide");
+        score = score - 3;
     };
 
     // Function to resume the timer -- call this function when nextQBtn is clicked
@@ -222,7 +223,7 @@ $(document).ready(function () {
     function submitGame() {
         // Get user input from an input field with id "userInput" using jQuery
         var userInput = $('#userInput').val();
-        var score = 77; //NEED TO BE DELETE WHEN LOCAL VAR SCORE WILL BE AVAILABLE.
+        // var score = 77; //NEED TO BE DELETE WHEN LOCAL VAR SCORE WILL BE AVAILABLE.
         // Get the current score from a local variable.
         var currentScore = score;
         // Retrieve existing scores from local storage or initialize an empty array


### PR DESCRIPTION
Corrected spelling of movie "Pinapple Express" ---> "Pineapple Express". This was breaking the functionality of the API fetch as there is no movie with that title.

Have also implemented a live counting system for the score. 

- Default score is set to 30 (3 points max per question with 10 questions). 
- If the user clicks "Give me a clue", it deducts 1 point from the score.
- If they click "One more clue" it removes a further point from their score. 
- If the user guesses incorrectly, it removes 3 points from their score.
- If they need both clues and they get the answer wrong, it removes 5 points from their score.

The score is now saved to local storage and displays the correct end score on the leaderboard page.